### PR TITLE
Filter out nan values before mapping pointclouds

### DIFF
--- a/Bonxai_ros/bonxai_server/include/bonxai_server.hpp
+++ b/Bonxai_ros/bonxai_server/include/bonxai_server.hpp
@@ -7,6 +7,7 @@
 
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/filters/filter.h>
 #include <pcl/filters/extract_indices.h>
 #include <pcl/filters/passthrough.h>
 #include <pcl/common/transforms.h>

--- a/Bonxai_ros/bonxai_server/package.xml
+++ b/Bonxai_ros/bonxai_server/package.xml
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>

--- a/Bonxai_ros/bonxai_server/src/bonxai_server.cpp
+++ b/Bonxai_ros/bonxai_server/src/bonxai_server.cpp
@@ -189,6 +189,10 @@ void BonxaiServer::insertCloudCallback(const PointCloud2::ConstSharedPtr cloud)
           .matrix()
           .cast<float>();
 
+  // remove nan values (e.g. from an organized pointcloud)
+  std::vector<int> indices;
+  pcl::removeNaNFromPointCloud(pc, pc, indices);
+  
   // Transforming Points to Global Reference Frame
   pcl::transformPointCloud(pc, pc, sensor_to_world);
 


### PR DESCRIPTION
If you pass a pointcloud with nan points, bonxai_server should ignore these. Otherwise, if we try to ray trace to nan, nan, nan with bonxai, it will 1. not really be meaningful, and 2. eat up a lot of memory